### PR TITLE
Reduce time to failure when unable to dial registry

### DIFF
--- a/rootfs/pull_test.go
+++ b/rootfs/pull_test.go
@@ -1,14 +1,32 @@
 package rootfs
 
 import (
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/ForAllSecure/rootfs_builder/rootfs"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPull(t *testing.T) {
-	pullable, err := NewPullableImage("../config.json")
+	pullable, err := rootfs.NewPullableImage("../test/alpine.json")
 	require.NoError(t, err)
 	_, err = pullable.Pull()
 	require.NoError(t, err)
+}
+
+func TestPullTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timeout test in short mode")
+	}
+
+	pullable, err := rootfs.NewPullableImage("../test/timeout.json")
+	require.NoError(t, err)
+
+	start := time.Now()
+	_, err = pullable.Pull()
+	require.Less(t, int64(time.Since(start)/time.Second), int64(60))
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "i/o timeout"))
 }

--- a/test/timeout.json
+++ b/test/timeout.json
@@ -1,0 +1,8 @@
+{
+    "Name": "192.0.2.1:5000/does/not/exist",
+    "Retries": 10,
+    "Spec": {
+        "Dest": "/test",
+        "User": "root"
+    }
+}


### PR DESCRIPTION
Right now it takes an excessively long amount of time to fail when unable to dial registry, about 25 minutes with 10 retries enabled. This appears to be because the default dial timeout used is 30 seconds, go-containerregistry bakes in 5 retries, and then we do 10 retries on top of that. On dial timeout, fail fast by reducing dial timeout to 10s and rely on the 5 baked-in retries rather than multiplying by our own retry logic.